### PR TITLE
Atom title is not displayed

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -175,7 +175,7 @@ func (p *RSSFeedPlugin) processAtomSubscription(subscription *Subscription) erro
 
 		for _, link := range item.Link {
 			if link.Rel == "alternate" {
-				post = link.Href + "\n"
+				post = post + link.Href + "\n"
 			}
 		}
 		if item.Content != nil {


### PR DESCRIPTION
I found Atom title is not displayed in the posts of  this plugin.
I think it might be caused by overwriting title by link in process of building post.
What if we add link to the post instead of that?