### PR TITLE
Post customization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
+	golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b
 	google.golang.org/appengine v1.6.1 // indirect
 	google.golang.org/genproto v0.0.0-20190626174449-989357319d63 // indirect
 	google.golang.org/grpc v1.21.1 // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -25,8 +25,48 @@
                 "display_name": "Show Description in RSS post.",
                 "type": "bool",
                 "help_text": "(Optional) Use this field to hide the description in rss post (Useful if link already returns a valid link back to post)."
+            },
+            {
+                "key": "ShowSummary",
+                "display_name": "Show Summary in Atom post.",
+                "type": "bool",
+                "help_text": "(Optional) Use this field to hide the summary in Atom post (Useful if link already returns a valid link back to post)."
+            },
+            {
+                "key": "ShowContent",
+                "display_name": "Show Content in Atom post.",
+                "type": "bool",
+                "help_text": "(Optional) Specify, whether the content of an Atom feed should be posted",
+                "default": true
+            },
+            {
+                "key": "ShowRSSLink",
+                "display_name": "Show Link in RSS post.",
+                "type": "bool",
+                "help_text": "(Optional) Specify, whether the link of an RSS feed should be posted",
+                "default": true
+            },
+            {
+                "key": "ShowAtomLink",
+                "display_name": "Show Link in Atom post.",
+                "type": "bool",
+                "help_text": "(Optional) Specify, whether the Link of an Atom feed should be posted",
+                "default": true
+            },
+            {
+                "key": "ShowRSSItemTitle",
+                "display_name": "Show Title in RSS post.",
+                "type": "bool",
+                "help_text": "(Optional) Specify, whether the title of an RSS feed should be posted",
+                "default": true
+            },
+            {
+                "key": "ShowAtomItemTitle",
+                "display_name": "Show Title in Atom post.",
+                "type": "bool",
+                "help_text": "(Optional) Specify, whether the title of an Atom feed should be posted",
+                "default": true
             }
-            
         ]
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -19,7 +19,13 @@
                 "display_name": "Time window between rss feed checks (minutes).",
                 "type": "text",
                 "help_text": "This is used to set a timer for the system to know when to go check to see if there is any new data in the subscribed rss feeds.  Defaults to 15 minutes."
-            },
+            },            
+            {
+                "key": "FormatTitle",
+                "display_name": "Print post title in bold",
+                "type": "bool",
+                "help_text": "(Optional) If enabled, the title of posts will be formatted in bold."
+            },            
             {
                 "key": "ShowDescription",
                 "display_name": "Show Description in RSS post.",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -26,6 +26,7 @@ type configuration struct {
 	ShowAtomLink      bool
 	ShowRSSItemTitle  bool
 	ShowAtomItemTitle bool
+	FormatTitle				bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -18,8 +18,14 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	Heartbeat       string
-	ShowDescription bool
+	Heartbeat         string
+	ShowDescription   bool
+	ShowSummary       bool
+	ShowContent       bool
+	ShowRSSLink       bool
+	ShowAtomLink      bool
+	ShowRSSItemTitle  bool
+	ShowAtomItemTitle bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -157,7 +157,7 @@ func (p *RSSFeedPlugin) processRSSV2Subscription(subscription *Subscription) err
 		}
 
 		if config.ShowRSSLink {
-			post = post + trimWhitespace(item.Link) + "\n"
+			post = post + strings.TrimSpace(item.Link) + "\n"
 		}
 		if config.ShowDescription {
 			post = post + html2md.Convert(item.Description) + "\n"
@@ -209,7 +209,7 @@ func (p *RSSFeedPlugin) processAtomSubscription(subscription *Subscription) erro
 		if config.ShowAtomLink {
 			for _, link := range item.Link {
 				if link.Rel == "alternate" {
-					post = post + trimWhitespace(link.Href) + "\n"
+					post = post + strings.TrimSpace(link.Href) + "\n"
 				}
 			}
 		}
@@ -246,7 +246,7 @@ func (p *RSSFeedPlugin) processAtomSubscription(subscription *Subscription) erro
 func tryParseRichNode(node *atom.Text, post *string) bool {
 	if node != nil {
 		if node.Type != "text" {
-			*post = *post + html2md.Convert(node.Body) + "\n"
+			*post = *post + html2md.Convert(strings.TrimSpace(node.Body)) + "\n"
 		} else {
 			*post = *post + node.Body + "\n"
 		}
@@ -254,14 +254,6 @@ func tryParseRichNode(node *atom.Text, post *string) bool {
 	} else {
 		return false
 	}
-}
-
-func trimWhitespace(text string) string {
-	text = strings.TrimPrefix(text, "\n")
-	text = strings.TrimSuffix(text, "\n")
-	text = strings.TrimSpace(text)
-
-	return text
 }
 
 func (p *RSSFeedPlugin) createBotPost(channelID string, message string, postType string) error {


### PR DESCRIPTION
Hello,

this Pull Request adds some customization options to the Plugin. 

In Particular, the following functions have been added:
- Showing the Summary of an Atom Post
- Formatting of the title of Atom and RSS posts in boldface

Both can be enabled or disabled through the plugin settings.

The following customization options have been added:
- Show or hide content of Atom post
- Show or hide link of RSS post
- Show or hide link of Atom post
- Show or hide title of RSS post
- Show or hide title of Atom post

Additionally, leading and trailing whitespaces of the links (RSS and Atom), as well as the Atom content and summary will be stripped out, as the whitespaces could cause formatting issues with the resulting markdown.
