### PR TITLE
Format Feed links as Markdown links

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -165,7 +165,8 @@ func (p *RSSFeedPlugin) processRSSV2Subscription(subscription *Subscription) err
 		}
 
 		if config.ShowRSSLink {
-			post = post + strings.TrimSpace(item.Link) + "\n"
+			var link = strings.TrimSpace(item.Link)
+			post = post + "[" + link + "]" + "(" + link + ")" + "\n"
 		}
 		if config.ShowDescription {
 			post = post + html2md.Convert(item.Description) + "\n"
@@ -223,7 +224,8 @@ func (p *RSSFeedPlugin) processAtomSubscription(subscription *Subscription) erro
 		if config.ShowAtomLink {
 			for _, link := range item.Link {
 				if link.Rel == "alternate" {
-					post = post + strings.TrimSpace(link.Href) + "\n"
+					var link = strings.TrimSpace(link.Href)
+					post = post + "[" + link + "]" + "(" + link + ")" + "\n"
 				}
 			}
 		}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -166,7 +166,7 @@ func (p *RSSFeedPlugin) processRSSV2Subscription(subscription *Subscription) err
 
 		if config.ShowRSSLink {
 			var link = strings.TrimSpace(item.Link)
-			post = post + "[" + link + "]" + "(" + link + ")" + "\n"
+			post = post + "[" + link + "]" + "(<" + link + ">)" + "\n"
 		}
 		if config.ShowDescription {
 			post = post + html2md.Convert(item.Description) + "\n"
@@ -225,7 +225,7 @@ func (p *RSSFeedPlugin) processAtomSubscription(subscription *Subscription) erro
 			for _, link := range item.Link {
 				if link.Rel == "alternate" {
 					var link = strings.TrimSpace(link.Href)
-					post = post + "[" + link + "]" + "(" + link + ")" + "\n"
+					post = post + "[" + link + "]" + "(<" + link + ">)" + "\n"
 				}
 			}
 		}


### PR DESCRIPTION
Some feeds do not properly URL encode their links. Links containing for example spaces would only halfway be recognized as links in the post. This PR adds Markdown link formatting around feed links so they get properly URL encoded by Mattermost.