### PR TITLE
Unsubscribe broken feeds automatically

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "rssfeed",
-	Version: "0.2.6"
+	Version: "0.2.6",
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -82,6 +82,11 @@ func (p *RSSFeedPlugin) processHeartBeat() error {
 		err := p.processSubscription(value)
 		if err != nil {
 			p.API.LogError(err.Error())
+			p.API.LogInfo(fmt.Sprintf("Unsubscribing invalid URL %s from channel %s", value.URL, value.ChannelID))
+			err := p.unsubscribe(value.ChannelID, value.URL)
+			if err != nil {
+				p.API.LogError(err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
We've had several users add a subscription with a broken URL, and then forget about it, which leads to an error being logged every 15 minutes per broken subscription.

It seems that we might as well automatically unsubscribe, if the subscription is broken.

To improve this further, `unsubscribe` could post in the associated channel to let users know.